### PR TITLE
Support default field values

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Where:
 - `store_name` The name of the store.
 - `name` The name of the accessor to the store.
 - `type` A symbol such as `:string` or `:integer`, or a type object to be used for the accessor.
-- `options` (optional) A hash of cast type options such as `precision`, `limit`, `scale`.
+- `options` (optional) A hash of cast type options such as `precision`, `limit`, `scale`, `default`.
 
 Type casting occurs every time you write data through accessor or update store itself
 and when object is loaded from database.
@@ -46,6 +46,7 @@ class MegaUser < User
   store_attribute :settings, :ratio, :integer, limit: 1
   store_attribute :settings, :login_at, :datetime
   store_attribute :settings, :active, :boolean
+  store_attribute :settings, :color, :string, default: "red"
 end
 
 u = MegaUser.new(active: false, login_at: "2015-01-01 00:01", ratio: "63.4608")
@@ -54,6 +55,8 @@ u.login_at.is_a?(DateTime) # => true
 u.login_at = DateTime.new(2015, 1, 1, 11, 0, 0)
 u.ratio # => 63
 u.active # => false
+# Default value is set
+u.color # => red
 # And we also have a predicate method
 u.active? # => false
 u.reload

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ class MegaUser < User
   store_attribute :settings, :login_at, :datetime
   store_attribute :settings, :active, :boolean
   store_attribute :settings, :color, :string, default: "red"
+  store_attribute :settings, :data, :datetime, default: -> { Time.now }
 end
 
 u = MegaUser.new(active: false, login_at: "2015-01-01 00:01", ratio: "63.4608")
@@ -57,6 +58,8 @@ u.ratio # => 63
 u.active # => false
 # Default value is set
 u.color # => red
+# A dynamic default can also be provided
+u.data # => Current time
 # And we also have a predicate method
 u.active? # => false
 u.reload

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           if value.key?(key)
             typed_casted[key] = type.serialize(value[key])
           elsif defaults.key?(str_key)
-            typed_casted[key] = type.serialize(get_default(key))
+            typed_casted[key] = type.serialize(get_default(str_key))
           end
         end
         super(value.merge(typed_casted))
@@ -88,6 +88,7 @@ module ActiveRecord
       def key_to_cast(val, key)
         return key if val.key?(key)
         return key.to_sym if val.key?(key.to_sym)
+        return key if defaults.key?(key)
       end
 
       def typed?(key)

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -24,6 +24,7 @@ describe StoreAttribute do
   let(:time) { DateTime.new(2015, 2, 14, 17, 0, 0) }
   let(:time_str) { "2015-02-14 17:00" }
   let(:time_str_utc) { "2015-02-14 17:00:00 UTC" }
+  let(:default_date) { User::DEFAULT_DATE }
 
   context "hstore" do
     it "typecasts on build" do
@@ -31,6 +32,7 @@ describe StoreAttribute do
       expect(user.visible).to eq true
       expect(user).to be_visible
       expect(user.login_at).to eq time
+      expect(user.safe_date).to eq default_date
     end
 
     it "typecasts on reload" do
@@ -41,6 +43,7 @@ describe StoreAttribute do
       expect(user.visible).to eq true
       expect(user).to be_visible
       expect(user.login_at).to eq time
+      expect(user.safe_date).to eq default_date
     end
 
     it "works with accessors" do
@@ -54,6 +57,7 @@ describe StoreAttribute do
       expect(user.visible).to be false
       expect(user).not_to be_visible
       expect(user.login_at).to eq time
+      expect(user.safe_date).to eq default_date
 
       ron = RawUser.find(user.id)
       expect(ron.hdata["visible"]).to eq "false"
@@ -70,6 +74,7 @@ describe StoreAttribute do
 
       expect(dumped.visible).to be false
       expect(dumped.login_at).to eq time
+      expect(dumped.safe_date).to eq default_date
     end
   end
 
@@ -85,6 +90,7 @@ describe StoreAttribute do
       expect(jamie.birthday).to eq Date.new(2000, 1, 1)
       expect(jamie.jparams["birthday"]).to eq Date.new(2000, 1, 1)
       expect(jamie.jparams["active"]).to eq true
+      expect(jamie.jparams["safe_date"]).to eq default_date
     end
 
     it "typecasts on reload" do
@@ -96,6 +102,7 @@ describe StoreAttribute do
       expect(jamie.birthday).to eq Date.new(2000, 1, 1)
       expect(jamie.jparams["birthday"]).to eq Date.new(2000, 1, 1)
       expect(jamie.jparams["active"]).to eq true
+      expect(jamie.jparams["safe_date"]).to eq default_date
     end
 
     it "works with accessors" do
@@ -109,6 +116,7 @@ describe StoreAttribute do
       expect(john).to be_active
       expect(john.birthday).to eq Date.new(2012, 1, 1)
       expect(john.salary).to eq 123
+      expect(john.jparams["safe_date"]).to eq default_date
 
       john.save!
 
@@ -116,15 +124,23 @@ describe StoreAttribute do
       expect(ron.jparams["active"]).to eq true
       expect(ron.jparams["birthday"]).to eq "2012-01-01"
       expect(ron.jparams["salary"]).to eq 123
+      expect(ron.jparams["safe_date"]).to eq default_date.to_s
     end
 
     it "re-typecast old data" do
       jamie = User.create!
-      User.update_all('jparams = \'{"active":"1", "salary":"12.02"}\'::jsonb')
+      User.update_all(
+        'jparams = \'{'\
+          '"active":"1",'\
+          '"salary":"12.02",'\
+          '"safe_date":"' + default_date.to_s + '"'\
+        '}\'::jsonb'
+      )
 
       jamie = User.find(jamie.id)
       expect(jamie).to be_active
       expect(jamie.salary).to eq 12
+      expect(jamie.safe_date).to eq default_date
 
       jamie.save!
 

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -23,6 +23,7 @@ describe StoreAttribute do
 
   let(:date) { Date.new(2019, 7, 17) }
   let(:default_date) { User::DEFAULT_DATE }
+  let(:dynamic_date) { User::TODAY_DATE }
   let(:time) { DateTime.new(2015, 2, 14, 17, 0, 0) }
   let(:time_str) { "2015-02-14 17:00" }
   let(:time_str_utc) { "2015-02-14 17:00:00 UTC" }
@@ -203,7 +204,7 @@ describe StoreAttribute do
     it "should handle a lambda" do
       jamie = User.create!
       jamie = User.find(jamie.id)
-      expect(jamie.dynamic_date).to eq(default_date)
+      expect(jamie.dynamic_date).to eq(dynamic_date)
     end
 
     it "should handle nil" do

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -130,11 +130,11 @@ describe StoreAttribute do
     it "re-typecast old data" do
       jamie = User.create!
       User.update_all(
-        'jparams = \'{'\
+        "jparams = '{"\
           '"active":"1",'\
           '"salary":"12.02",'\
           '"safe_date":"' + default_date.to_s + '"'\
-        '}\'::jsonb'
+        "}'::jsonb"
       )
 
       jamie = User.find(jamie.id)

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -116,6 +116,25 @@ describe ActiveRecord::Type::TypedStore do
 
         expect { subject.serialize(val: 1024) }.to raise_error(RangeError)
       end
+
+      it "with type key and a default" do
+        date = ::Date.new(2016, 6, 22)
+        subject.add_typed_key("date", :date, default: date)
+        expect(subject.serialize({})).to eq({date: date}.to_json)
+      end
+
+      it "with type key and a dynamic default" do
+        date = ::Date.today
+        default = -> { date }
+        subject.add_typed_key("date", :date, default: default)
+        expect(subject.serialize({})).to eq({date: date}.to_json)
+      end
+
+      it "with a symbolic type key" do
+        date = ::Date.new(2016, 6, 22)
+        subject.add_typed_key(:date, :date, default: date)
+        expect(subject.serialize({})).to eq({date: date}.to_json)
+      end
     end
 
     describe ".create_from_type" do
@@ -209,6 +228,13 @@ describe ActiveRecord::Type::TypedStore do
       subject.add_typed_key("date", :date, default: default)
 
       expect(subject.deserialize("---\ndate: #{date}\n")).to eq("date" => date)
+    end
+
+    it "with a default" do
+      default = ::Date.new(2019, 7, 17)
+      subject.add_typed_key("date", :date, default: default)
+      expected = "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndate: 2019-07-17\n"
+      expect(subject.serialize({})).to eq(expected)
     end
   end
 end

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -189,6 +189,13 @@ describe ActiveRecord::Type::TypedStore do
       expect(subject.deserialize("---\n")).to eq("date" => default)
     end
 
+    it "uses dynamic default" do
+      default = -> { ::Date.new(2019, 7, 17) }
+      subject.add_typed_key("date", :date, default: default)
+
+      expect(subject.deserialize("---\n")).to eq("date" => default.call)
+    end
+
     it "keeps explicit nil" do
       default = ::Date.new(2019, 7, 17)
       subject.add_typed_key("date", :date, default: default)

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -28,6 +28,13 @@ describe ActiveRecord::Type::TypedStore do
         expect(subject.cast({})).to eq("date" => date)
       end
 
+      it "with dynamic default" do
+        date = ::Date.new(2016, 6, 22)
+        subject.add_typed_key("date", :date, default: -> { date })
+
+        expect(subject.cast({})).to eq("date" => date)
+      end
+
       it "with default and explicit nil" do
         date = ::Date.new(2016, 6, 22)
         subject.add_typed_key("date", :date, default: date)
@@ -62,6 +69,13 @@ describe ActiveRecord::Type::TypedStore do
       it "with default" do
         date = ::Date.new(2016, 6, 22)
         subject.add_typed_key("date", :date, default: date)
+
+        expect(subject.deserialize("{}")).to eq("date" => date)
+      end
+
+      it "with dynamic default" do
+        date = ::Date.new(2016, 6, 22)
+        subject.add_typed_key("date", :date, default: -> { date })
 
         expect(subject.deserialize("{}")).to eq("date" => date)
       end
@@ -118,6 +132,13 @@ describe ActiveRecord::Type::TypedStore do
       it "accepts default", :aggregate_failures do
         default = 1
         type = described_class.create_from_type(json_type, "val", :date, default: default)
+
+        expect(type.cast({})).to eq("val" => default)
+      end
+
+      it "accepts dynamic default", :aggregate_failures do
+        default = 1
+        type = described_class.create_from_type(json_type, "val", :date, default: -> { default })
 
         expect(type.cast({})).to eq("val" => default)
       end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -6,11 +6,12 @@ end
 
 class User < ActiveRecord::Base
   DEFAULT_DATE = ::Date.new(2019, 7, 17)
+  TODAY_DATE = ::Date.today
 
   store_accessor :jparams, :version, active: :boolean, salary: :integer
   store_attribute :jparams, :birthday, :date
   store_attribute :jparams, :static_date, :date, default: DEFAULT_DATE
-  store_attribute :jparams, :dynamic_date, :date, default: -> { DEFAULT_DATE }
+  store_attribute :jparams, :dynamic_date, :date, default: -> { TODAY_DATE }
   store_attribute :jparams, :empty_date, :date, default: nil
   store_attribute :jparams, :inner_json, :json
 

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -5,9 +5,13 @@ class RawUser < ActiveRecord::Base
 end
 
 class User < ActiveRecord::Base
+  DEFAULT_LOCALE = "en-US"
+  DEFAULT_DATE = ::Date.new(2019, 7, 17)
+
   store_accessor :jparams, :version, active: :boolean, salary: :integer
   store_attribute :jparams, :birthday, :date
-
+  store_attribute :jparams, :safe_date, :date, default: DEFAULT_DATE
+  store_attribute :jparams, :safe_locale, :string, default: DEFAULT_LOCALE
   store_attribute :jparams, :inner_json, :json
 
   store :custom, accessors: [price: :money_type]

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -5,13 +5,13 @@ class RawUser < ActiveRecord::Base
 end
 
 class User < ActiveRecord::Base
-  DEFAULT_LOCALE = "en-US"
   DEFAULT_DATE = ::Date.new(2019, 7, 17)
 
   store_accessor :jparams, :version, active: :boolean, salary: :integer
   store_attribute :jparams, :birthday, :date
-  store_attribute :jparams, :safe_date, :date, default: DEFAULT_DATE
-  store_attribute :jparams, :safe_locale, :string, default: DEFAULT_LOCALE
+  store_attribute :jparams, :static_date, :date, default: DEFAULT_DATE
+  store_attribute :jparams, :dynamic_date, :date, default: -> { DEFAULT_DATE }
+  store_attribute :jparams, :empty_date, :date, default: nil
   store_attribute :jparams, :inner_json, :json
 
   store :custom, accessors: [price: :money_type]


### PR DESCRIPTION
Hey @palkan! I've noticed [this post](https://cultofmartians.com/tasks/store-attribute-defaults.html) and decided to help with the implementation. It is a nice feature that I'd probably find a good use myself.

I've done quick research, and reproduced Attributes API behavior. Here is a quick demo:

```ruby
class CreatePosts < ActiveRecord::Migration[5.2]
  def change
    create_table :posts do |t|
      t.json :settings, null: false, default: {}

      t.timestamps
    end
  end
end
```

```ruby
Post.new.settings
=> {"color"=>"red"}
```

```ruby
Post.new.color
=> "red"
```

```ruby
Post.new(color: "banana").settings
=> {"color"=>"banana"}
```

```ruby
Post.create!(color: 'banana')
   (0.2ms)  begin transaction
  Post Create (0.8ms)  INSERT INTO "posts" ("settings", "created_at", "updated_at") VALUES (?, ?, ?)  [["settings", "{\"color\":\"banana\"}"], ["created_at", "2019-07-18 17:49:09.112486"], ["updated_at", "2019-07-18 17:49:09.112486"]]
   (1.5ms)  commit transaction
=> #<Post id: 4, date: nil, settings: {"color"=>"banana"}, created_at: "2019-07-18 17:49:09", updated_at: "2019-07-18 17:49:09">
```

```ruby
Post.new.save!
   (0.1ms)  begin transaction
  Post Create (0.4ms)  INSERT INTO "posts" ("created_at", "updated_at") VALUES (?, ?)  [["created_at", "2019-07-18 17:44:40.160795"], ["updated_at", "2019-07-18 17:44:40.160795"]]
   (2.0ms)  commit transaction
=> true

pp Post.last
  Post Load (0.1ms)  SELECT  "posts".* FROM "posts" ORDER BY "posts"."id" DESC LIMIT ?  [["LIMIT", 1]]
#<Post:0x00007fe878a0df58
 id: 2,
 date: nil,
 settings: {"color"=>"red"},
 created_at: Thu, 18 Jul 2019 17:44:40 UTC +00:00,
 updated_at: Thu, 18 Jul 2019 17:44:40 UTC +00:00>
```

Please take a look at the patch and let me know if it's necessary to update anything.

I have a question, though. Is it necessary to support dynamic (lambda) values for the `default` argument, or to follow the example from [this comment](https://github.com/palkan/store_attribute/issues/6#issuecomment-497358643)? At the moment `default` support static values only.

PS: I've seen SumLare's comment in the #6 discussion. Please disregard my PR if the help is not necessary any longer. I had no intention to interfere if this is the case.