### PR TITLE
Allow the store method on ActiveRecord to be called without accessors

### DIFF
--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       def store(store_name, options = {})
         accessors = options.delete(:accessors)
         typed_accessors =
-          if accessors.last.is_a?(Hash)
+          if accessors && accessors.last.is_a?(Hash)
             accessors.pop
           else
             {}

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -244,4 +244,18 @@ describe StoreAttribute do
       expect(user.visible_before_last_save).to eq nil
     end
   end
+
+  context "original store implementation" do
+    it "doesn't break original store when no accessors passed" do
+      dummy_class = Class.new(ActiveRecord::Base) do
+        self.table_name = "users"
+
+        store :custom, coder: JSON
+      end
+
+      dummy = dummy_class.new(custom: {key: "text"})
+
+      expect(dummy.custom).to eq({"key" => "text"})
+    end
+  end
 end


### PR DESCRIPTION
We were using this gem for a long time and everything was working nicely. Currently, we are in the process of adding the [Mobility](https://github.com/shioyama/mobility) gem to our codebase, with the [Container](https://github.com/shioyama/mobility/wiki/Container-Backend) backend, that also uses a `jsonb` column and therefore the [`ActiveRecord::Store`](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/store.rb) methods.

Setting up the gem, I was seeing an error, when the `store` method was called:

```
NoMethodError: undefined method `last' for nil:NilClass
/Users/klaustopher/.rvm/gems/ruby-2.6.6/gems/store_attribute-0.7.0/lib/store_attribute/active_record/store.rb:29:in `store'
```

Investigating further, the Container Backend of the mobility gem, just calls `store` with the column name and its coder, but does not provide any accessors:

https://github.com/shioyama/mobility/blob/568174f3a405fcd4ee41d8615fca0cbd2359472c/lib/mobility/backends/active_record/container.rb#L90

Looking at the rails implementation of the `store` method, this is a perfectly valid use case. In this case, only the serialization would be set up, without generating any accessor methods:

https://github.com/rails/rails/blob/82f861855c23e6f0005a3222e1238efb2baa270a/activerecord/lib/active_record/store.rb#L104-L107

So, this patch simply allows the `store` function defined by this gem, to also be called without the `accessors` parameter. 

Unfortunately I could not find a place to add tests for this behavior, would be nice, if you could point me in the direction where I could add some tests that this behavior still works.

Thanks