### PR TITLE
Update gem version to "~> 0.8.0" on install instructions for Rails 5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your Gemfile:
 
 ```ruby
 # for Rails 5+ (6 is supported)
-gem "store_attribute", "~> 0.5.0"
+gem "store_attribute", "~> 0.8.0"
 
 # for Rails 4.2
 gem "store_attribute", "~> 0.4.0"


### PR DESCRIPTION
Installing version `~> 0.5.0` raises an error when using with Rails 6.1, although the issue [was already solved on this commit](https://github.com/palkan/store_attribute/commit/3df318fb6f6761c9d3b3fedc33cb74fd021ceb33). The recommended version for Rails 5+ should be `~> 0.8.0`.

Thank you for your great work on this gem!