### PR TITLE
Default values should not be marked dirty

### DIFF
--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -167,7 +167,9 @@ module ActiveRecord
             end
 
             define_method(accessor_key) do
-              read_store_attribute(store_name, key)
+              next_value = read_store_attribute(store_name, key)
+              clear_attribute_change(store_name) unless changed?
+              next_value
             end
           end
         end

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -65,6 +65,7 @@ module ActiveRecord
 
         _store_accessors_module.module_eval do
           define_method("changes") do
+            return @changes if defined?(@changes)
             changes = super()
             self.class.local_stored_attributes.each do |accessor, attributes|
               next unless attribute_changed?(accessor)
@@ -77,7 +78,7 @@ module ActiveRecord
                 end
               end
             end
-            changes
+            @changes = changes
           end
         end
 

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -66,8 +66,7 @@ module ActiveRecord
         _store_accessors_module.module_eval do
           define_method("changes") do
             changes = super()
-            local_stored_attributes = self.class.local_stored_attributes
-            local_stored_attributes.each do |accessor, attributes|
+            self.class.local_stored_attributes.each do |accessor, attributes|
               next unless attribute_changed?(accessor)
 
               prev_store, new_store = changes[accessor]

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -43,6 +43,10 @@ module ActiveRecord
         hash
       end
 
+      def changed_in_place?(raw_old_value, new_value)
+        raw_old_value != serialize(new_value)
+      end
+
       def serialize(value)
         return super(value) unless value.is_a?(Hash)
         typed_casted = {}

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -212,6 +212,12 @@ describe StoreAttribute do
       jamie = User.find(jamie.id)
       expect(jamie.empty_date).to be_nil
     end
+
+    it "should not mark as dirty" do
+      jamie = User.create!
+      jamie.static_date
+      expect(jamie.changes).to eq({})
+    end
   end
 
   context "prefix/suffix" do
@@ -255,6 +261,8 @@ describe StoreAttribute do
       expect(user.login_at_change[0]).to be_nil
       expect(user.login_at_change[1].to_i).to eq now.to_i
       expect(user.login_at_was).to eq nil
+
+      expect(user.changes["hdata"]).to eq ([{}, { "login_at" => now.to_s(:db), "visible" => false }])
     end
 
     it "should report saved changes" do

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -218,6 +218,14 @@ describe StoreAttribute do
       jamie.static_date
       expect(jamie.changes).to eq({})
     end
+
+    it "should only include changed accessors" do
+      jamie = User.create!
+      jamie.static_date
+      jamie.visible = true
+      jamie.active = true
+      expect(jamie.changes).to eq({"hdata"=>[{}, {"visible"=>true}], "jparams"=>[{}, {"active" => true}]})
+    end
   end
 
   context "prefix/suffix" do
@@ -275,6 +283,12 @@ describe StoreAttribute do
       expect(user.saved_change_to_visible?).to be true
       expect(user.saved_change_to_visible).to eq [nil, false]
       expect(user.visible_before_last_save).to eq nil
+    end
+
+    it "should only report on changed accessors" do
+      user.active = true
+      expect(user.changes["jparams"]).to eq([{}, {"active" => true}])
+      expect(user.static_date_changed?).to be false
     end
   end
 


### PR DESCRIPTION
Fixes #12

### What is the purpose of this pull request?
Don't mark attributes that have a default value as dirty when they haven't actually changed

### What changes did you make? (overview)
~From https://api.rubyonrails.org/classes/ActiveModel/Type/Value.html#method-i-changed_in_place-3F~

~Only mark the value as changed if it differs from the read value from the database, before being cast.~

Overwrite `changes` and compare the previous and current values and remove them from the hash if they're the same. It's sloppy but effective.

### Is there anything you'd like reviewers to focus on?
~This is unfamiliar Rails core territory to me so my confidence is not super high. I tried a few approaches and this seemed to get the closest to where I was expecting to need to make the call but I could be missing something.~

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
