### PR TITLE
Fix store mutation during changes calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix bug with store mutation during changes calculation. ([@palkan][])
+
 ## 0.9.1
 
 - Fix bug with dirty nullable stores. ([@palkan][])

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -292,6 +292,33 @@ describe StoreAttribute do
       expect(user.static_date_changed?).to be false
     end
 
+    it "works with reload" do
+      user.active = true
+      expect(user.changes["jparams"]).to eq([{}, {"active" => true}])
+      user.save!
+
+      user.reload
+      user.static_date = Date.today + 2.days
+
+      expect(user.static_date_changed?).to be true
+      expect(user.active_changed?).to be false
+    end
+
+    it "should not modify stores" do
+      user.price = 99.0
+      expect(user.changes["custom"]).to eq([{}, {"price" => 99}])
+      user.save!
+
+      user.reload
+      user.custom_date = Date.today + 2.days
+
+      expect(user.custom_date_changed?).to be true
+      expect(user.price_changed?).to be false
+      user.save!
+
+      expect(user.reload.price).to be 99
+    end
+
     # https://github.com/palkan/store_attribute/issues/19
     it "without defaults" do
       user = UserWithoutDefaults.new

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -23,7 +23,8 @@ class User < ActiveRecord::Base
 
   store_accessor :jparams, active: :boolean, birthday: :date, prefix: "json", suffix: "value"
 
-  store :custom, accessors: [price: :money_type]
+  store :custom, accessors: [:custom_date, price: :money_type]
+  after_initialize { self.custom_date = TODAY_DATE }
 
   store_accessor :hdata, visible: :boolean
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Closes #20

### What changes did you make? (overview)

- Do not memoize `@changes` (otherwise `.reload` or multiple `.update` wouldn't work correctly)
- Do not mutate changes data, use `.dup` instead (otherwise the original store could be corrupted).

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
