### PR TITLE
Inspect reloaded object should maintain changes

### DIFF
--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -199,7 +199,11 @@ module ActiveRecord
                 end
               end
 
-              changes[accessor] = prev_store, new_store
+              if prev_store.empty? && new_store.empty?
+                changes.delete(accessor)
+              else
+                changes[accessor] = prev_store, new_store
+              end
             end
             changes
           end

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -319,6 +319,13 @@ describe StoreAttribute do
       expect(user.reload.price).to be 99
     end
 
+    it "should not include empty changes" do
+      reloaded_user = User.take
+      reloaded_user.inspect
+
+      expect(reloaded_user.changes).to eq({})
+    end
+
     # https://github.com/palkan/store_attribute/issues/19
     it "without defaults" do
       user = UserWithoutDefaults.new


### PR DESCRIPTION
### What is the purpose of this pull request?
Documents and fixes an issue found while using the gem. I can't quite understand what part of re-initializing and calling inspect causes the issue and would love to find out!

### What changes did you make? (overview)
Clear the changes hash for an accessor if there are no changes to the attributes

### Is there anything you'd like reviewers to focus on?
Why the hell does this happen? :D

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
