### PR TITLE
Fix things getting marked as dirty during initialization

### DIFF
--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -208,6 +208,20 @@ module ActiveRecord
             changes
           end
 
+          define_method("changed") do
+            changes.keys
+          end
+
+          define_method("changed?") do
+            changes.any?
+          end
+
+          define_method("changed_attributes") do
+            changes.each_with_object({}) do |(key, (before, after)), hash|
+              hash[key] = before
+            end
+          end
+
           keys.flatten.each do |key|
             key = key.to_s
             accessor_key = "#{prefix}#{key}#{suffix}"

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -43,10 +43,6 @@ module ActiveRecord
         hash
       end
 
-      def changed_in_place?(_raw_old_value, _new_value)
-        false
-      end
-
       def serialize(value)
         return super(value) unless value.is_a?(Hash)
         typed_casted = {}

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         hash
       end
 
-      def changed_in_place?(raw_old_value, new_value)
+      def changed_in_place?(_raw_old_value, _new_value)
         false
       end
 

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       end
 
       def changed_in_place?(raw_old_value, new_value)
-        raw_old_value != serialize(new_value)
+        false
       end
 
       def serialize(value)

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -319,11 +319,25 @@ describe StoreAttribute do
       expect(user.reload.price).to be 99
     end
 
-    it "should not include empty changes" do
+    it "should not mark attributes as dirty after reading original values" do
       reloaded_user = User.take
       reloaded_user.inspect
 
       expect(reloaded_user.changes).to eq({})
+      expect(reloaded_user.changed_attributes).to eq({})
+      expect(reloaded_user.changed?).to be false
+    end
+
+    it "should not mark attributes as dirty after default values are set" do
+      new_user = User.new
+
+      expect(new_user.changed_attributes).to eq({"custom"=>{}})
+      expect(new_user.changed?).to be true
+
+      new_user.jparams
+
+      expect(new_user.changed_attributes).to eq({"custom"=>{}})
+      expect(new_user.changed?).to be true
     end
 
     # https://github.com/palkan/store_attribute/issues/19

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -331,12 +331,12 @@ describe StoreAttribute do
     it "should not mark attributes as dirty after default values are set" do
       new_user = User.new
 
-      expect(new_user.changed_attributes).to eq({"custom"=>{}})
+      expect(new_user.changed_attributes).to eq({"custom" => {}})
       expect(new_user.changed?).to be true
 
       new_user.jparams
 
-      expect(new_user.changed_attributes).to eq({"custom"=>{}})
+      expect(new_user.changed_attributes).to eq({"custom" => {}})
       expect(new_user.changed?).to be true
     end
 


### PR DESCRIPTION
### What is the purpose of this pull request?
Overwrite more dirty methods. I tried several ways to get to the underlying database_mutations or resetting the attributes after defaults had been set but this was just the easiest sadly.

### What changes did you make? (overview)
Add more overwritten dirty methods

### Is there anything you'd like reviewers to focus on?
Tests

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
