### PR TITLE
v1.0

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -34,9 +34,6 @@ jobs:
         - ruby: "2.6"
           postgres: "12"
           gemfile: "gemfiles/rails6.gemfile"
-        - ruby: "2.5"
-          postgres: "11"
-          gemfile: "gemfiles/rails5.gemfile"
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,7 +30,7 @@ jobs:
           gemfile: "gemfiles/railsmaster.gemfile"
         - ruby: "2.7"
           postgres: "12"
-          gemfile: "gemfiles/rails6.gemfile"
+          gemfile: "gemfiles/rails60.gemfile"
         - ruby: "2.6"
           postgres: "12"
           gemfile: "gemfiles/rails6.gemfile"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ require:
 inherit_gem:
   standard: config/base.yml
 
+inherit_from:
+  - .rubocop/rubocop_rspec.yml
+
 AllCops:
   Exclude:
     - 'bin/*'
@@ -13,7 +16,7 @@ AllCops:
     - 'bench/**/*'
   DisplayCopNames: true
   SuggestExtensions: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Standard/BlockSingleLineBraces:
   Enabled: false

--- a/.rubocop/rubocop_rspec.yml
+++ b/.rubocop/rubocop_rspec.yml
@@ -1,0 +1,56 @@
+require:
+  - rubocop-rspec
+
+RSpec:
+  Enabled: false
+
+RSpec/Focus:
+  Enabled: true
+
+RSpec/EmptyExampleGroup:
+  Enabled: true
+
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: true
+
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: true
+
+RSpec/EmptyLineAfterHook:
+  Enabled: true
+
+RSpec/EmptyLineAfterSubject:
+  Enabled: true
+
+RSpec/HookArgument:
+  Enabled: true
+
+RSpec/HooksBeforeExamples:
+  Enabled: true
+
+RSpec/ImplicitExpect:
+  Enabled: true
+
+RSpec/IteratedExpectation:
+  Enabled: true
+
+RSpec/LetBeforeExamples:
+  Enabled: true
+
+RSpec/MissingExampleGroupArgument:
+  Enabled: true
+
+RSpec/ReceiveCounts:
+  Enabled: true
+
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
+
+RSpec/IdenticalEqualityAssertion: # new in 2.4
+  Enabled: true
+
+RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+
+RSpec/Rails/AvoidSetupHook: # new in 2.4
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master
 
+## 1.0.0-dev
+
+- **Ruby 2.6+ and Rails 6+** is required.
+
+- Refactored internal implementation to use Rails Store implementation as much as possible. ([@palkan][])
+
+Use existing Attributes API and Store API instead of duplicating and monkey-patching. Dirty-tracking, accessors and prefixes/suffixes are now handled by Rails. We only provide type coercions for stores.
+
 ## 0.9.3 (2021-11-17)
 
 - Fix keeping empty store hashes in the changes. ([@markedmondson][])

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "pry-byebug", platform: :mri
+gem "debug", platform: :mri
 
 eval_gemfile "gemfiles/rubocop.gemfile"
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 ActiveRecord extension which adds typecasting to store accessors.
 
-Compatible with Rails 4.2 and Rails 5+.
-
-Extracted from not merged PR to Rails: [rails/rails#18942](https://github.com/rails/rails/pull/18942).
+Originally extracted from not merged PR to Rails: [rails/rails#18942](https://github.com/rails/rails/pull/18942).
 
 ### Install
 
 In your Gemfile:
 
 ```ruby
+# for Rails 6+ (7 is supported)
+gem "store_attribute", "~> 1.0"
+
 # for Rails 5+ (6 is supported)
 gem "store_attribute", "~> 0.8.0"
 
@@ -31,6 +32,7 @@ store_attribute(store_name, name, type, options)
 ```
 
 Where:
+
 - `store_name` The name of the store.
 - `name` The name of the accessor to the store.
 - `type` A symbol such as `:string` or `:integer`, or a type object to be used for the accessor.

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.1.0'
-
-gemspec path: '..'

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 6.0.0'
+
+gemspec path: '..'

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org" do
   gem "rubocop-md", "~> 1.0"
+  gem "rubocop-rspec"
   gem "standard", "~> 1.0"
-  gem "ruby-next", ">= 0.12"
 end

--- a/lib/store_attribute/active_record/mutation_tracker.rb
+++ b/lib/store_attribute/active_record/mutation_tracker.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module StoreAttribute
+  # Upgrade mutation tracker to return partial changes for typed stores
+  module MutationTracker
+    def change_to_attribute(attr_name)
+      return super unless attributes[attr_name].type.is_a?(ActiveRecord::Type::TypedStore)
+
+      orig_changes = super
+
+      return unless orig_changes
+
+      prev_store, new_store = orig_changes.map(&:dup)
+
+      prev_store&.each do |key, value|
+        if new_store[key] == value
+          prev_store.except!(key)
+          new_store&.except!(key)
+        end
+      end
+
+      [prev_store, new_store]
+    end
+  end
+end
+
+require "active_model/attribute_mutation_tracker"
+ActiveModel::AttributeMutationTracker.prepend(StoreAttribute::MutationTracker)

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -155,13 +155,9 @@ module ActiveRecord
 
         attribute(attr_name, default: defaultik.proc) do |subtype|
           subtypes = _local_typed_stored_attributes[attr_name]
-          type =
-            if defined?(_lookup_cast_type)
-              Type::TypedStore.create_from_type(_lookup_cast_type(attr_name, was_type, {}))
-            else
-              Type::TypedStore.create_from_type(subtype)
-            end
+          subtype = _lookup_cast_type(attr_name, was_type, {}) if defined?(_lookup_cast_type)
 
+          type = Type::TypedStore.create_from_type(subtype)
           defaultik.type = type
           subtypes.each { |name, (cast_type, default)| type.add_typed_key(name, cast_type, default: default) }
 

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -121,7 +121,7 @@ module ActiveRecord
         _orig_store_accessor(store_name, name.to_s, prefix: prefix, suffix: suffix)
         _define_predicate_method(name, prefix: prefix, suffix: suffix) if type == :boolean
 
-        _define_store_attribute(store_name) if _local_typed_stored_attributes[store_name].empty?
+        _define_store_attribute(store_name) if !_local_typed_stored_attributes? || _local_typed_stored_attributes[store_name].empty?
         _store_local_stored_attribute(store_name, name, type, **options)
       end
 
@@ -130,8 +130,12 @@ module ActiveRecord
         _local_typed_stored_attributes[store_name][key] = [cast_type, default]
       end
 
+      def _local_typed_stored_attributes?
+        instance_variable_defined?(:@local_typed_stored_attributes)
+      end
+
       def _local_typed_stored_attributes
-        return @local_typed_stored_attributes if instance_variable_defined?(:@local_typed_stored_attributes)
+        return @local_typed_stored_attributes if _local_typed_stored_attributes?
 
         @local_typed_stored_attributes =
           if superclass.respond_to?(:_local_typed_stored_attributes)

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -7,8 +7,8 @@ require "store_attribute/active_record/mutation_tracker"
 module ActiveRecord
   module Store
     module ClassMethods # :nodoc:
-      alias_method :_orig_store, :store
-      alias_method :_orig_store_accessor, :store_accessor
+      alias_method :_orig_store_without_types, :store
+      alias_method :_orig_store_accessor_without_types, :store_accessor
 
       # Defines store on this model.
       #
@@ -35,7 +35,7 @@ module ActiveRecord
             {}
           end
 
-        _orig_store(store_name, options)
+        _orig_store_without_types(store_name, options)
         store_accessor(store_name, *accessors, **typed_accessors) if accessors
       end
 
@@ -60,7 +60,7 @@ module ActiveRecord
         keys = keys.flatten
         typed_keys = typed_keys.except(keys)
 
-        _orig_store_accessor(store_name, *(keys - typed_keys.keys), prefix: nil, suffix: nil)
+        _orig_store_accessor_without_types(store_name, *(keys - typed_keys.keys), prefix: nil, suffix: nil)
 
         typed_keys.each do |key, type|
           store_attribute(store_name, key, type, prefix: prefix, suffix: suffix)
@@ -118,7 +118,7 @@ module ActiveRecord
       #
       # For more examples on using types, see documentation for ActiveRecord::Attributes.
       def store_attribute(store_name, name, type, prefix: nil, suffix: nil, **options)
-        _orig_store_accessor(store_name, name.to_s, prefix: prefix, suffix: suffix)
+        _orig_store_accessor_without_types(store_name, name.to_s, prefix: prefix, suffix: suffix)
         _define_predicate_method(name, prefix: prefix, suffix: suffix) if type == :boolean
 
         _define_store_attribute(store_name) if !_local_typed_stored_attributes? || _local_typed_stored_attributes[store_name].empty?

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -20,6 +20,8 @@ module ActiveRecord
       # Creates +TypedStore+ type instance and specifies type caster
       # for key.
       def self.create_from_type(basetype, **options)
+        return basetype.dup if basetype.is_a?(self)
+
         new(basetype)
       end
 
@@ -93,6 +95,13 @@ module ActiveRecord
         defaults.transform_values do |val|
           val.is_a?(Proc) ? val.call : val
         end.with_indifferent_access
+      end
+
+      def dup
+        self.class.new(__getobj__).tap do |dtype|
+          dtype.accessor_types.merge!(accessor_types)
+          dtype.defaults.merge!(defaults)
+        end
       end
 
       protected

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -359,11 +359,15 @@ describe StoreAttribute do
     let(:raw_klass) do
       Class.new(RawUser).tap do |kl|
         kl.include concern
+
+        kl.store_attribute :jparams, :some_flag, :boolean, default: true
       end
     end
 
     let(:klass) do
       Class.new(User).tap do |kl|
+        kl.store_attribute :jparams, :some_flag, :boolean, default: true
+
         kl.include concern
       end
     end
@@ -371,17 +375,26 @@ describe StoreAttribute do
     specify do
       user = klass.new
       expect(user.beginning_of_week).to eq 6
+      expect(user.some_flag).to eq(true)
       user.save!
 
-      expect(klass.type_for_attribute(:extra).inspect).to include(
-        "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb"
-      )
-      expect(raw_klass.type_for_attribute(:extra).inspect).to include(
-        "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb"
+      user = klass.find(user.id)
+      expect(user).to have_attributes(
+        beginning_of_week: 6,
+        some_flag: true
       )
 
-      reuser = klass.find(user.id)
-      expect(reuser.beginning_of_week).to eq 6
+      ruser = raw_klass.new(beginning_of_week: "4")
+
+      expect(ruser.beginning_of_week).to eq 4
+      expect(ruser.some_flag).to eq(true)
+      ruser.save!
+
+      ruser = raw_klass.find(ruser.id)
+      expect(ruser).to have_attributes(
+        beginning_of_week: 4,
+        some_flag: true
+      )
     end
   end
 end

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -396,5 +396,20 @@ describe StoreAttribute do
         some_flag: true
       )
     end
+
+    specify "double encoding" do
+      user = klass.create!(inner_json: %w[kis kis])
+
+      user = klass.find(user.id)
+      expect(user).to have_attributes(
+        inner_json: %w[kis kis]
+      )
+
+      # Parent class should also be able to decode the attribute
+      pre_user = User.find(user.id)
+      expect(pre_user).to have_attributes(
+        inner_json: %w[kis kis]
+      )
+    end
   end
 end

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -3,23 +3,8 @@
 require "spec_helper"
 
 describe StoreAttribute do
-  before do
-    @connection = ActiveRecord::Base.connection
-
-    @connection.transaction do
-      @connection.create_table("users") do |t|
-        t.jsonb :extra
-        t.jsonb :jparams, default: {}, null: false
-        t.text :custom
-        t.hstore :hdata, default: {}, null: false
-      end
-    end
-
-    User.reset_column_information
-  end
-
   after do
-    @connection.drop_table "users", if_exists: true
+    User.delete_all
   end
 
   let(:date) { Date.new(2019, 7, 17) }
@@ -135,11 +120,13 @@ describe StoreAttribute do
       expect(jamie).to be_active
       expect(jamie.salary).to eq 12
 
+      jamie.salary = 13
+
       jamie.save!
 
       ron = RawUser.find(jamie.id)
       expect(ron.jparams["active"]).to eq true
-      expect(ron.jparams["salary"]).to eq 12
+      expect(ron.jparams["salary"]).to eq 13
     end
   end
 
@@ -324,6 +311,8 @@ describe StoreAttribute do
       reloaded_user.inspect
 
       expect(reloaded_user.changes).to eq({})
+      expect(reloaded_user.changed_attributes).to eq({})
+      expect(reloaded_user.changed?).to be false
     end
 
     # https://github.com/palkan/store_attribute/issues/19

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 begin
-  require "pry-byebug"
+  require "debug"
 rescue LoadError
 end
 
 require "active_record"
 require "pg"
 require "store_attribute"
-
-RAILS_5_1 = ActiveRecord.version.release >= Gem::Version.new("5.1.0")
 
 connection_params =
   if ENV.key?("DATABASE_URL")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-begin
-  require "debug"
-rescue LoadError
-end
-
 require "active_record"
 require "pg"
 require "store_attribute"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "debug" unless ENV["CI"]
 require "active_record"
 require "pg"
 require "store_attribute"

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -79,6 +79,7 @@ describe ActiveRecord::Type::TypedStore do
       it "creates with valid types", :aggregate_failures do
         type = described_class.create_from_type(json_type)
         type.add_typed_key("date", :date)
+
         new_type = described_class.create_from_type(type)
         new_type.add_typed_key("val", :integer)
 

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -20,37 +20,6 @@ describe ActiveRecord::Type::TypedStore do
         date = ::Date.new(2016, 6, 22)
         expect(subject.cast(date: "2016-06-22")).to eq("date" => date)
       end
-
-      it "with default" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: date)
-
-        expect(subject.cast({})).to eq("date" => date)
-      end
-
-      it "with dynamic default" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: -> { date })
-
-        expect(subject.cast({})).to eq("date" => date)
-      end
-
-      it "with default and explicit nil" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: date)
-        nil_date = {"date" => nil}
-
-        expect(subject.cast(nil_date)).to eq(nil_date)
-      end
-
-      it "with default and existing value" do
-        default = ::Date.new(2016, 6, 22)
-        expected = ::Date.new(2019, 7, 17)
-        subject.add_typed_key("date", :date, default: default)
-        date = {"date" => expected}
-
-        expect(subject.cast("date" => expected.to_s)).to eq(date)
-      end
     end
 
     describe "#deserialize" do
@@ -64,37 +33,6 @@ describe ActiveRecord::Type::TypedStore do
 
         date = ::Date.new(2016, 6, 22)
         expect(subject.deserialize('{"date":"2016-06-22"}')).to eq("date" => date)
-      end
-
-      it "with default" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: date)
-
-        expect(subject.deserialize("{}")).to eq("date" => date)
-      end
-
-      it "with dynamic default" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: -> { date })
-
-        expect(subject.deserialize("{}")).to eq("date" => date)
-      end
-
-      it "with default and explicit nil" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: date)
-        s11n = {"date" => nil}.to_json
-
-        expect(subject.deserialize(s11n)).to eq("date" => nil)
-      end
-
-      it "with default and existing value" do
-        default = ::Date.new(2016, 6, 22)
-        expected = ::Date.new(2019, 7, 17)
-        subject.add_typed_key("date", :date, default: default)
-        s11n = {"date" => expected}.to_json
-
-        expect(subject.deserialize(s11n)).to eq("date" => expected)
       end
     end
 
@@ -116,77 +54,54 @@ describe ActiveRecord::Type::TypedStore do
 
         expect { subject.serialize(val: 1024) }.to raise_error(RangeError)
       end
+    end
 
-      it "with type key and a default" do
-        date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key("date", :date, default: date)
-        expect(subject.serialize({})).to eq({date: date}.to_json)
+    describe "Defaultik" do
+      let(:type) { described_class.new(json_type) }
+
+      subject do
+        described_class::Defaultik.new.tap do |df|
+          df.type = type
+        end.then(&:proc)
       end
 
-      it "with type key and a dynamic default" do
-        date = ::Date.today
-        default = -> { date }
-        subject.add_typed_key("date", :date, default: default)
-        expect(subject.serialize({})).to eq({date: date}.to_json)
-      end
-
-      it "with a symbolic type key" do
+      specify do
         date = ::Date.new(2016, 6, 22)
-        subject.add_typed_key(:date, :date, default: date)
-        expect(subject.serialize({})).to eq({date: date}.to_json)
+        ddate = ::Date.new(2021, 11, 23)
+        type.add_typed_key("date", :date, default: date)
+        type.add_typed_key("another_date", :date, default: -> { ddate })
+
+        expect(subject.call).to eq("date" => date, "another_date" => ddate)
       end
     end
 
     describe ".create_from_type" do
       it "creates with valid types", :aggregate_failures do
-        type = described_class.create_from_type(json_type, "date", :date)
-        new_type = described_class.create_from_type(type, "val", :integer)
+        type = described_class.create_from_type(json_type)
+        type.add_typed_key("date", :date)
+        new_type = described_class.create_from_type(type)
+        new_type.add_typed_key("val", :integer)
 
         date = ::Date.new(2016, 6, 22)
 
         expect(type.cast(date: "2016-06-22", val: "1.2")).to eq("date" => date, "val" => "1.2")
         expect(new_type.cast(date: "2016-06-22", val: "1.2")).to eq("date" => date, "val" => 1)
       end
-
-      it "accepts default", :aggregate_failures do
-        default = 1
-        type = described_class.create_from_type(json_type, "val", :date, default: default)
-
-        expect(type.cast({})).to eq("val" => default)
-      end
-
-      it "accepts dynamic default", :aggregate_failures do
-        default = 1
-        type = described_class.create_from_type(json_type, "val", :date, default: -> { default })
-
-        expect(type.cast({})).to eq("val" => default)
-      end
     end
   end
 
   context "with yaml coder" do
-    if RAILS_5_1
-      let(:yaml_type) do
-        ActiveRecord::Type::Serialized.new(
-          ActiveRecord::Type::Text.new,
-          ActiveRecord::Store::IndifferentCoder.new(
-            "test",
-            ActiveRecord::Coders::YAMLColumn.new("test", Hash)
-          )
+    let(:yaml_type) do
+      ActiveRecord::Type::Serialized.new(
+        ActiveRecord::Type::Text.new,
+        ActiveRecord::Store::IndifferentCoder.new(
+          "test",
+          ActiveRecord::Coders::YAMLColumn.new("test", Hash)
         )
-      end
-    else
-      let(:yaml_type) do
-        ActiveRecord::Type::Serialized.new(
-          ActiveRecord::Type::Text.new,
-          ActiveRecord::Store::IndifferentCoder.new(
-            ActiveRecord::Coders::YAMLColumn.new(Hash)
-          )
-        )
-      end
+      )
     end
 
-    let(:subject) { described_class.new(yaml_type) }
+    subject { described_class.new(yaml_type) }
 
     it "works", :aggregate_failures do
       subject.add_typed_key("date", :date)
@@ -199,42 +114,6 @@ describe ActiveRecord::Type::TypedStore do
       expect(subject.deserialize("---\ndate: 2016-06-22\n")).to eq("date" => date)
       expect(subject.serialize(date: date)).to eq "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndate: 2016-06-22\n"
       expect(subject.serialize("date" => date)).to eq "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndate: 2016-06-22\n"
-    end
-
-    it "uses default" do
-      default = ::Date.new(2019, 7, 17)
-      subject.add_typed_key("date", :date, default: default)
-
-      expect(subject.deserialize("---\n")).to eq("date" => default)
-    end
-
-    it "uses dynamic default" do
-      default = -> { ::Date.new(2019, 7, 17) }
-      subject.add_typed_key("date", :date, default: default)
-
-      expect(subject.deserialize("---\n")).to eq("date" => default.call)
-    end
-
-    it "keeps explicit nil" do
-      default = ::Date.new(2019, 7, 17)
-      subject.add_typed_key("date", :date, default: default)
-
-      expect(subject.deserialize("---\ndate: null\n")).to eq("date" => nil)
-    end
-
-    it "keeps existing value" do
-      default = ::Date.new(2019, 7, 17)
-      date = ::Date.new(2016, 6, 22)
-      subject.add_typed_key("date", :date, default: default)
-
-      expect(subject.deserialize("---\ndate: #{date}\n")).to eq("date" => date)
-    end
-
-    it "with a default" do
-      default = ::Date.new(2019, 7, 17)
-      subject.add_typed_key("date", :date, default: default)
-      expected = "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndate: 2019-07-17\n"
-      expect(subject.serialize({})).to eq(expected)
     end
   end
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -6,6 +6,7 @@ connection.drop_table "users", if_exists: true
 
 connection.transaction do
   connection.create_table("users") do |t|
+    t.string :name
     t.jsonb :extra
     t.string :dyndate
     t.string :statdate

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+connection = ActiveRecord::Base.connection
+
+connection.drop_table "users", if_exists: true
+
+connection.transaction do
+  connection.create_table("users") do |t|
+    t.jsonb :extra
+    t.string :dyndate
+    t.string :statdate
+    t.jsonb :jparams, default: {}, null: false
+    t.text :custom
+    t.hstore :hdata, default: {}, null: false
+  end
+end
+
 class RawUser < ActiveRecord::Base
   self.table_name = "users"
 end
@@ -13,6 +28,9 @@ end
 class User < ActiveRecord::Base
   DEFAULT_DATE = ::Date.new(2019, 7, 17)
   TODAY_DATE = ::Date.today
+
+  attribute :dyndate, :datetime, default: -> { ::Time.now }
+  attribute :statdate, :datetime, default: ::Time.now
 
   store_accessor :jparams, :version, active: :boolean, salary: :integer
   store_attribute :jparams, :birthday, :date

--- a/store_attribute.gemspec
+++ b/store_attribute.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "http://github.com/palkan/store_attribute"
   }
 
-  s.add_runtime_dependency "activerecord", ">= 5.0"
+  s.add_runtime_dependency "activerecord", ">= 6.0"
 
   s.add_development_dependency "pg", ">= 0.18"
   s.add_development_dependency "rake", ">= 13.0"

--- a/store_attribute.gemspec
+++ b/store_attribute.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.txt CHANGELOG.md]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.6.0"
 
   s.metadata = {
     "bug_tracker_uri" => "http://github.com/palkan/store_attribute/issues",


### PR DESCRIPTION
- [x] Stop copy-pasting Rails internals.
- [x] Be a wrapper/extender, not patcher.
- [x] Use canonical Attributes API to define store attributes and their defaults.
- [x] **Drop Rails 5 and Ruby 2.5**