### PR TITLE
Standardize the way prefixes and suffixes are used in predicate methods

### DIFF
--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -182,8 +182,27 @@ module ActiveRecord
       end
 
       def _define_predicate_method(name, prefix: nil, suffix: nil)
+        accessor_prefix =
+          case prefix
+          when String, Symbol
+            "#{prefix}_"
+          when TrueClass
+            "#{name}_"
+          else
+            ""
+          end
+        accessor_suffix =
+          case suffix
+          when String, Symbol
+            "_#{suffix}"
+          when TrueClass
+            "_#{name}"
+          else
+            ""
+          end
+
         _store_accessors_module.module_eval do
-          name = "#{prefix}#{name}#{suffix}"
+          name = "#{accessor_prefix}#{name}#{accessor_suffix}"
 
           define_method("#{name}?") do
             send(name) == true

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -222,6 +222,7 @@ describe StoreAttribute do
       jamie = User.find(jamie.id)
 
       expect(jamie.json_active_value).to eql(true)
+      expect(jamie.json_active_value?).to eql(true)
       expect(jamie.json_birthday_value).to eq(Time.local(2019, 6, 26).to_date)
 
       jamie.json_active_value = false


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes:
-->

### What is the purpose of this pull request?
Standardizes the way prefixes and suffixes are used when defining predicate methods for boolean accessors. 

### What changes did you make? (overview)
Updated the way `_define_predicate_method` uses prefixes and suffixes to match the way they are used in `_orig_store_accessor_without_types`. 


### Is there anything you'd like reviewers to focus on?

### Checklist

- [X] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
