### PR TITLE
feat: register store_attributes as attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## master
 
+- Register store_attributes as attributes. ([@rickcsong](https://github.com/rickcsong))
+
+```ruby
+class User < ActiveRecord::Base
+  self.store_attribute_register_attributes = true
+
+  store_attribute :extra, :color, :string, default: "grey"
+end
+
+User.attribute_types.keys.include?('color') #=> true
+```
+
 ## 2.0.0 (2024-12-12)
 
 - **Breaking:** The `store_attribute_unset_values_fallback_to_default` option is now true by default, meaning that the default value will be returned when the attribute key is not present in the serialized value.

--- a/lib/store_attribute.rb
+++ b/lib/store_attribute.rb
@@ -8,7 +8,9 @@ module StoreAttribute
     # Global default value for `store_attribute_unset_values_fallback_to_default` option.
     # Must be set before any model is loaded
     attr_accessor :store_attribute_unset_values_fallback_to_default
+    attr_accessor :store_attribute_register_attributes
   end
 
   self.store_attribute_unset_values_fallback_to_default = true
+  self.store_attribute_register_attributes = false
 end

--- a/lib/store_attribute/active_record/mutation_tracker.rb
+++ b/lib/store_attribute/active_record/mutation_tracker.rb
@@ -14,7 +14,7 @@ module StoreAttribute
       prev_store, new_store = orig_changes.map(&:dup)
 
       prev_store&.each do |key, value|
-        if new_store[key] == value
+        if new_store&.dig(key) == value
           prev_store.except!(key)
           new_store&.except!(key)
         end

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -10,6 +10,7 @@ module ActiveRecord
       alias_method :_orig_store_without_types, :store
       alias_method :_orig_store_accessor_without_types, :store_accessor
 
+      attr_writer :store_attribute_register_attributes
       attr_writer :store_attribute_unset_values_fallback_to_default
 
       # Defines store on this model.
@@ -133,6 +134,28 @@ module ActiveRecord
 
         _local_typed_stored_attributes[store_name][:owner] = self if options.key?(:default) || !_local_typed_stored_attributes?
         _local_typed_stored_attributes[store_name][:types][name] = [type, options]
+
+        if store_attribute_register_attributes
+          cast_type =
+            if type == :value
+              ActiveModel::Type::Value.new(**options.except(:default))
+            else
+              ActiveRecord::Type.lookup(type, **options.except(:default))
+            end
+
+          attribute(name, cast_type, **options)
+        end
+      end
+
+      def store_attribute_register_attributes
+        return @store_attribute_register_attributes if instance_variable_defined?(:@store_attribute_register_attributes)
+
+        @store_attribute_register_attributes =
+          if superclass.respond_to?(:store_attribute_register_attributes)
+            superclass.store_attribute_register_attributes
+          else
+            StoreAttribute.store_attribute_register_attributes
+          end
       end
 
       def store_attribute_unset_values_fallback_to_default

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -331,6 +331,24 @@ describe StoreAttribute do
     end
   end
 
+  context "attributes" do
+    it "should register all store_attributes as attributes" do
+      expect(User.attribute_types).to include(
+        'active' => an_instance_of(ActiveModel::Type::Boolean),
+        'salary' => an_instance_of(ActiveModel::Type::Integer),
+        'birthday' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        'static_date' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        'dynamic_date' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        'empty_date' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        'inner_json' => an_instance_of(ActiveRecord::Type::Json),
+        'price' => an_instance_of(MoneyType),
+        'visible' => an_instance_of(ActiveModel::Type::Boolean),
+        'ratio' => an_instance_of(ActiveModel::Type::Integer),
+        'login_at' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime),
+      )
+    end
+  end
+
   context "dirty tracking" do
     let(:user) { User.create! }
     let(:now) { Time.now.utc }

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -334,17 +334,17 @@ describe StoreAttribute do
   context "attributes" do
     it "should register all store_attributes as attributes" do
       expect(User.attribute_types).to include(
-        'active' => an_instance_of(ActiveModel::Type::Boolean),
-        'salary' => an_instance_of(ActiveModel::Type::Integer),
-        'birthday' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
-        'static_date' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
-        'dynamic_date' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
-        'empty_date' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
-        'inner_json' => an_instance_of(ActiveRecord::Type::Json),
-        'price' => an_instance_of(MoneyType),
-        'visible' => an_instance_of(ActiveModel::Type::Boolean),
-        'ratio' => an_instance_of(ActiveModel::Type::Integer),
-        'login_at' => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime),
+        "active" => an_instance_of(ActiveModel::Type::Boolean),
+        "salary" => an_instance_of(ActiveModel::Type::Integer),
+        "birthday" => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        "static_date" => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        "dynamic_date" => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        "empty_date" => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date),
+        "inner_json" => an_instance_of(ActiveRecord::Type::Json),
+        "price" => an_instance_of(MoneyType),
+        "visible" => an_instance_of(ActiveModel::Type::Boolean),
+        "ratio" => an_instance_of(ActiveModel::Type::Integer),
+        "login_at" => an_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime)
       )
     end
   end
@@ -430,7 +430,7 @@ describe StoreAttribute do
       expect(reloaded_user.changed?).to be false
     end
 
-    # https://github.com/palkan/store_attribute/issues/19
+    # https://github.com/palkan/store_as2ttribute/issues/19
     it "without defaults" do
       user = UserWithoutDefaults.new
       user.birthday = "2019-06-26"
@@ -455,6 +455,14 @@ describe StoreAttribute do
       jamie = klass.create!(jparams: {})
 
       expect(jamie.changes).to eq({})
+    end
+
+    it "works if store attribute column is set to nil" do
+      user.save!
+      user.hdata = nil
+
+      expect(user.visible_changed?).to be true
+      expect(user.login_at_changed?).to be true
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ require "openssl"
 require "pg"
 require "store_attribute"
 
+StoreAttribute.store_attribute_register_attributes = true
+
 connection_params =
   if ENV.key?("DATABASE_URL")
     {"url" => ENV["DATABASE_URL"]}

--- a/spec/support/money_type.rb
+++ b/spec/support/money_type.rb
@@ -2,7 +2,7 @@
 
 class MoneyType < ActiveRecord::Type::Integer
   def cast(value)
-    if !value.is_a?(Numeric) && value.include?("$")
+    if !value.is_a?(Numeric) && value&.include?("$")
       price_in_dollars = value.delete("$").to_f
       super(price_in_dollars * 100)
     else


### PR DESCRIPTION
Enables better compatibility with other gems (i.e. StoreModel) which rely on attributes being registered on the model.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- NOT NEEDED - I've updated a documentation (Readme)
