### PR TITLE
Configure missing attribute behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Allow configurable to return default values when attribute key is not present in the serialized value ([@markedmondson][])
+
 ## 1.0.2 (2022-07-29)
 
 - Fix possible conflicts with Active Model objects. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ another_user = User.find(another_raw_user.id)
 another_user.name #=> nil
 another_user.expired_at #=> nil
 ```
+
+It is possible to configure `store_attribute` to return the default value even when the record is persisted and the attribute name is not present. By using the `StoreAttribute.configuration.read_unset_returns_default = true`, default values will be returned for missing keys. For example:
+
+```ruby
+StoreAttribute.configuration.read_unset_returns_default = true
+user = User.create!(extra: {})
+user.expired_at => #=> 2022-03-19
+```
+

--- a/lib/store_attribute.rb
+++ b/lib/store_attribute.rb
@@ -2,3 +2,16 @@
 
 require "store_attribute/version"
 require "store_attribute/active_record"
+require "store_attribute/configuration"
+
+module StoreAttribute
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
+end

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -47,6 +47,8 @@ module ActiveRecord
         accessor_types.each do |key, type|
           if hash.key?(key)
             hash[key] = type.deserialize(hash[key])
+          elsif StoreAttribute.configuration.read_unset_returns_default && defaults.key?(key)
+            hash[key] = built_defaults[key]
           end
         end
         hash
@@ -105,6 +107,10 @@ module ActiveRecord
       end
 
       protected
+
+      def built_defaults
+        @built_defaults ||= build_defaults
+      end
 
       # We cannot rely on string keys 'cause user input can contain symbol keys
       def key_to_cast(val, key)

--- a/lib/store_attribute/configuration.rb
+++ b/lib/store_attribute/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StoreAttribute
   class Configuration
     attr_accessor :read_unset_returns_default

--- a/lib/store_attribute/configuration.rb
+++ b/lib/store_attribute/configuration.rb
@@ -1,0 +1,9 @@
+module StoreAttribute
+  class Configuration
+    attr_accessor :read_unset_returns_default
+
+    def initialize
+      @read_unset_returns_default = false
+    end
+  end
+end

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -228,6 +228,23 @@ describe StoreAttribute do
       jamie.active = true
       expect(jamie.changes).to eq({"hdata" => [{}, {"visible" => true}], "jparams" => [{}, {"active" => true}]})
     end
+
+    it "should not return defaults for missing attributes" do
+      jamie = User.create!(jparams: {})
+      expect(jamie.static_date).to be_nil
+      expect(jamie.dynamic_date).to be_nil
+    end
+
+    it "should set defaults for missing attributes when configured" do
+      StoreAttribute.configuration.read_unset_returns_default = true
+
+      jamie = User.create!(jparams: {})
+      jamie = User.find(jamie.id)
+      expect(jamie.static_date).to eq(date)
+      expect(jamie.dynamic_date).to eq(dynamic_date)
+    ensure
+      StoreAttribute.configuration.read_unset_returns_default = false
+    end
   end
 
   context "prefix/suffix" do
@@ -342,6 +359,21 @@ describe StoreAttribute do
       user.birthday = "2019-06-26"
 
       expect(user.birthday_changed?).to eq true
+    end
+
+    it "with defaults for missing attributes" do
+      jamie = User.create!(jparams: {})
+
+      expect(jamie.changes).to eq({})
+    end
+
+    it "with defaults for missing attributes when configured" do
+      StoreAttribute.configuration.read_unset_returns_default = true
+      jamie = User.create!(jparams: {})
+
+      expect(jamie.changes).to eq({})
+    ensure
+      StoreAttribute.configuration.read_unset_returns_default = false
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe StoreAttribute::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe "#initialize" do
+    it "sets defaults" do
+      expect(configuration.read_unset_returns_default).to be false
+    end
+  end
+
+  it "allows setting" do
+    configuration.read_unset_returns_default = true
+    expect(configuration.read_unset_returns_default).to be true
+  end
+end

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -34,6 +34,26 @@ describe ActiveRecord::Type::TypedStore do
         date = ::Date.new(2016, 6, 22)
         expect(subject.deserialize('{"date":"2016-06-22"}')).to eq("date" => date)
       end
+
+      it "with no default" do
+        subject.add_typed_key("val", :integer)
+
+        expect(subject.deserialize('{}')).to eq({})
+      end
+
+      it "with default" do
+        subject.add_typed_key("val", :integer, default: 1)
+
+        expect(subject.deserialize('{}')).to eq({})
+      end
+
+      it "with default configured to read_unset_returns_default" do
+        StoreAttribute.configuration.read_unset_returns_default = true
+
+        subject.add_typed_key("val", :integer, default: 1)
+
+        expect(subject.deserialize('{}')).to eq("val" => 1)
+      end
     end
 
     describe "#serialize" do

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -38,13 +38,13 @@ describe ActiveRecord::Type::TypedStore do
       it "with no default" do
         subject.add_typed_key("val", :integer)
 
-        expect(subject.deserialize('{}')).to eq({})
+        expect(subject.deserialize("{}")).to eq({})
       end
 
       it "with default" do
         subject.add_typed_key("val", :integer, default: 1)
 
-        expect(subject.deserialize('{}')).to eq({})
+        expect(subject.deserialize("{}")).to eq({})
       end
 
       it "with default configured to read_unset_returns_default" do
@@ -52,7 +52,7 @@ describe ActiveRecord::Type::TypedStore do
 
         subject.add_typed_key("val", :integer, default: 1)
 
-        expect(subject.deserialize('{}')).to eq("val" => 1)
+        expect(subject.deserialize("{}")).to eq("val" => 1)
       end
     end
 


### PR DESCRIPTION
### What is the purpose of this pull request?
Allow the configuration of the default behaviour when an attribute is missing. This was raised in #29, we toyed with various ideas on how to make this work (after_initialize callbacks, defining setters and getters, reverting to store_accessor and doing things manually) but ultimately we thought there was an argument for this being a configurable concept within the gem (the effort to re-implement typecasting and defaults seemed wasteful).

These changes allow you revert the behaviour so that given:

```ruby
class User < ActiveRecord::Base
  store_attribute :preferences, :color, :string, default: 'red'
end
```

`INSERT INTO "users" ("id", "preferences") VALUES (1, '{}');`

```
User.new.color => "red"
User.new.preferences => {"color"=>"red"}
User.first.color => "red"
User.first.preferences => {"color"=>"red"}
```

Our main argument was that in adding a new store_attribute to an existing serialized attribute shouldn't require you to repopulate all the data. If you were using a database to define the default value, ActiveRecord would return that for an object where the value wasn't defined, we wanted the option to mimic that behaviour.

### What changes did you make? (overview)
* Added a Configurable
* Added a block within the deserialize method to fallback to the default if the key was not found


### Is there anything you'd like reviewers to focus on?
Be kind please! :-)

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
