### PR TITLE
fix: don't require database connection when processing attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Do type lookup after schema load.
+
 ## 1.1.0 (2023-03-08) 🌷
 
 - Add configuration option to return default values when attribute key is not present in the serialized value ([@markedmondson][], [@palkan][]).

--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -138,9 +138,6 @@ module ActiveRecord
           end
       end
 
-      def _store_local_stored_attribute(store_name, key, cast_type, default: Type::TypedStore::UNDEFINED, **options) # :nodoc:
-      end
-
       def _local_typed_stored_attributes?
         instance_variable_defined?(:@local_typed_stored_attributes)
       end


### PR DESCRIPTION
Fixes #36

### What changes did you make? (overview)

Delay type lookup until attributes are being processed. They process right after `load_schema!` call.

- [x] Use late type lookup

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change -- No, because existing tests cover the change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation (Readme) - No, because it just reverts the behavior from versions 0.9
