### PR TITLE
Populate defaults when user input has missing keys

### DIFF
--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -80,6 +80,8 @@ module ActiveRecord
         accessor_types.each do |key, type|
           if hash.key?(key)
             hash[key] = type.cast(hash[key])
+          elsif fallback_to_default?(key)
+            hash[key] = built_defaults[key]
           end
         end
         hash

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -279,11 +279,6 @@ describe StoreAttribute do
 
       expect(jamie.reload.tags).to eq(["rails"])
     end
-
-    it "should affect an empty hash initialization" do
-      jamie = User.new(jparams: {})
-      expect(jamie.static_date).to eq(default_date)
-    end
   end
 
   context "prefix/suffix" do
@@ -551,6 +546,17 @@ describe StoreAttribute do
       user = RawUser.find(user.id)
 
       expect(user.jparams.keys).to include("some_flag", "static_date", "dynamic_date")
+
+      # But if fallback is enabled, it must populate defaults
+      subklass = Class.new(klass) do
+        self.store_attribute_unset_values_fallback_to_default = true
+
+        # We must redeclare at least a single attribute to associate it with the new class
+        store_attribute :jparams, :static_date, :date, default: User::DEFAULT_DATE
+      end
+
+      jamie = subklass.new(jparams: {})
+      expect(jamie.static_date).to eq(default_date)
     end
 
     specify "double encoding" do

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -279,6 +279,11 @@ describe StoreAttribute do
 
       expect(jamie.reload.tags).to eq(["rails"])
     end
+
+    it "should affect an empty hash initialization" do
+      jamie = User.new(jparams: {})
+      expect(jamie.static_date).to eq(default_date)
+    end
   end
 
   context "prefix/suffix" do


### PR DESCRIPTION
Fixes #45

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/palkan/store_attribute/issues/45?shareId=65bf2b17-a1fc-485f-97ee-063648f3e4d0).