### PR TITLE
fix: ensure typed store attributes are cast even without default option

### DIFF
--- a/lib/store_attribute/active_record/store.rb
+++ b/lib/store_attribute/active_record/store.rb
@@ -127,12 +127,11 @@ module ActiveRecord
 
         _define_store_attribute(store_name) if !_local_typed_stored_attributes? ||
           _local_typed_stored_attributes[store_name][:types].empty? ||
-          # Defaults owner has changed, we must decorate the attribute to correctly propagate the defaults
-          (
-            options.key?(:default) && _local_typed_stored_attributes[store_name][:owner] != self
-          )
+          # Owner has changed (e.g., subclass adding to inherited store),
+          # we must re-decorate the attribute to correctly set up type casting and defaults
+          _local_typed_stored_attributes[store_name][:owner] != self
 
-        _local_typed_stored_attributes[store_name][:owner] = self if options.key?(:default) || !_local_typed_stored_attributes?
+        _local_typed_stored_attributes[store_name][:owner] = self if !_local_typed_stored_attributes? || _local_typed_stored_attributes[store_name][:owner] != self
         _local_typed_stored_attributes[store_name][:types][name] = [type, options]
 
         # In case #decorate_attribute has already been invoked, add new type information right away

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -102,6 +102,32 @@ describe StoreAttribute do
       expect(jamie).to be_active
       expect(jamie.salary).to eq 100
     end
+
+    it "typecasts inherited typed store attributes without defaults on reload" do
+      subclass = Class.new(User) do
+        store_attribute :jparams, :amount, :decimal, precision: 15, scale: 2
+      end
+
+      record = subclass.create!(jparams: {"amount" => "12345.67"})
+      record.reload
+
+      expect(record.amount).to eq BigDecimal("12345.67")
+      expect(record.jparams["amount"]).to eq BigDecimal("12345.67")
+    end
+
+    it "typecasts typed store attributes without defaults on reload" do
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "users"
+
+        store_attribute :jparams, :amount, :decimal, precision: 15, scale: 2
+      end
+
+      record = klass.create!(jparams: {"amount" => "12345.67"})
+      record.reload
+
+      expect(record.amount).to eq BigDecimal("12345.67")
+      expect(record.jparams["amount"]).to eq BigDecimal("12345.67")
+    end
   end
 
   context "custom types" do


### PR DESCRIPTION
Fixes #49

  ### What is the purpose of this pull request?

  Fix incorrect type casting for `store_attribute` typed keys when `default:` is not provided.
  Previously, values could remain uncasted (e.g. `String` instead of `BigDecimal`) after create/load in some class ownership/decorated scenarios.

  ### What changes did you make? (overview)

  - Updated `store_attribute` setup logic in `lib/store_attribute/active_record/store.rb`:
    - Removed the `options.key?(:default)` gate from the owner-change re-decoration path.
    - Now re-decoration happens whenever store owner changes, not only for attributes with defaults.
    - Updated owner assignment condition accordingly.
  - Added regression specs in `spec/cases/store_attribute_spec.rb`:
    - `typecasts inherited typed store attributes without defaults on reload`
    - `typecasts typed store attributes without defaults on reload`

  ### Is there anything you'd like reviewers to focus on?

  Please focus on:
  - correctness of the owner/re-decoration condition in `store_attribute`
  - potential side effects for defaults behavior and STI/inheritance flows
  - whether test coverage is sufficient for the reported regression path

  ### Checklist

  - [x] I've added tests for this change
  - [ ] I've added a Changelog entry
  - [ ] I've updated a documentation (Readme)