### PR TITLE
fix: cast also when building the attribute from the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Cast values coming from attribute defaults ([@honeyryderchuck][]).
+
 ## 2.1.1 (2026-01-13)
 
 - Fix defining store attributes after schema loading. ([@palkan][])

--- a/lib/store_attribute/active_record/type/typed_store.rb
+++ b/lib/store_attribute/active_record/type/typed_store.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           if hash.key?(key)
             hash[key] = type.deserialize(hash[key])
           elsif fallback_to_default?(key)
-            hash[key] = built_defaults[key]
+            hash[key] = type.deserialize(built_defaults[key])
           end
         end
         hash
@@ -82,7 +82,7 @@ module ActiveRecord
           if hash.key?(key)
             hash[key] = type.cast(hash[key])
           elsif fallback_to_default?(key)
-            hash[key] = built_defaults[key]
+            hash[key] = type.cast(built_defaults[key])
           end
         end
         hash

--- a/spec/cases/store_attribute_spec.rb
+++ b/spec/cases/store_attribute_spec.rb
@@ -241,6 +241,19 @@ describe StoreAttribute do
 
       expect(jamie.reload.tags).to eq(["rails"])
     end
+
+    it "casts a raw default through the declared type" do
+      klass = Class.new(User) do
+        store_attribute :jparams, :due_at, :date, default: "2026-05-25"
+        store_attribute :jparams, :renews_at, :date, default: -> { "2026-06-01" }
+      end
+
+      jamie = klass.new(jparams: {})
+      expect(jamie.due_at).to eq(Date.new(2026, 5, 25))
+      expect(jamie.due_at).to be_a(Date)
+      expect(jamie.renews_at).to eq(Date.new(2026, 6, 1))
+      expect(jamie.renews_at).to be_a(Date)
+    end
   end
 
   context "prefix/suffix" do

--- a/spec/store_attribute/typed_store_spec.rb
+++ b/spec/store_attribute/typed_store_spec.rb
@@ -25,6 +25,61 @@ describe ActiveRecord::Type::TypedStore do
         date = ::Date.new(2016, 6, 22)
         expect(subject.cast(date: "2016-06-22")).to eq("date" => date)
       end
+
+      it "with no default" do
+        subject.add_typed_key("val", :integer)
+
+        expect(subject.cast({})).to eq({})
+      end
+
+      it "with default" do
+        subject.add_typed_key("val", :integer, default: 1)
+
+        expect(subject.cast({})).to eq({})
+      end
+
+      context "with owner configured to store_attribute_unset_values_fallback_to_default" do
+        before do
+          subject.owner = Struct.new(:store_attribute_unset_values_fallback_to_default).new(true)
+        end
+
+        it "casts a typed default" do
+          subject.add_typed_key("val", :integer, default: 1)
+
+          expect(subject.cast({})).to eq("val" => 1)
+        end
+
+        it "casts a string default to the declared type" do
+          date = ::Date.new(2016, 6, 22)
+          subject.add_typed_key("date", :date, default: "2016-06-22")
+
+          result = subject.cast({})
+          expect(result["date"]).to eq(date)
+          expect(result["date"]).to be_a(::Date)
+        end
+
+        it "casts a proc default to the declared type" do
+          date = ::Date.new(2016, 6, 22)
+          subject.add_typed_key("date", :date, default: -> { "2016-06-22" })
+
+          result = subject.cast({})
+          expect(result["date"]).to eq(date)
+          expect(result["date"]).to be_a(::Date)
+        end
+
+        it "leaves an already-typed default unchanged" do
+          date = ::Date.new(2016, 6, 22)
+          subject.add_typed_key("date", :date, default: date)
+
+          expect(subject.cast({})).to eq("date" => date)
+        end
+
+        it "preserves nil defaults" do
+          subject.add_typed_key("val", :integer, default: nil)
+
+          expect(subject.cast({})).to eq("val" => nil)
+        end
+      end
     end
 
     describe "#deserialize" do
@@ -52,12 +107,47 @@ describe ActiveRecord::Type::TypedStore do
         expect(subject.deserialize("{}")).to eq({})
       end
 
-      it "with owner configured to store_attribute_unset_values_fallback_to_default" do
-        subject.owner = Struct.new(:store_attribute_unset_values_fallback_to_default).new(true)
+      context "with owner configured to store_attribute_unset_values_fallback_to_default" do
+        before do
+          subject.owner = Struct.new(:store_attribute_unset_values_fallback_to_default).new(true)
+        end
 
-        subject.add_typed_key("val", :integer, default: 1)
+        it "deserializes a typed default" do
+          subject.add_typed_key("val", :integer, default: 1)
 
-        expect(subject.deserialize("{}")).to eq("val" => 1)
+          expect(subject.deserialize("{}")).to eq("val" => 1)
+        end
+
+        it "deserializes a string default to the declared type" do
+          date = ::Date.new(2016, 6, 22)
+          subject.add_typed_key("date", :date, default: "2016-06-22")
+
+          result = subject.deserialize("{}")
+          expect(result["date"]).to eq(date)
+          expect(result["date"]).to be_a(::Date)
+        end
+
+        it "deserializes a proc default to the declared type" do
+          date = ::Date.new(2016, 6, 22)
+          subject.add_typed_key("date", :date, default: -> { "2016-06-22" })
+
+          result = subject.deserialize("{}")
+          expect(result["date"]).to eq(date)
+          expect(result["date"]).to be_a(::Date)
+        end
+
+        it "leaves an already-typed default unchanged" do
+          date = ::Date.new(2016, 6, 22)
+          subject.add_typed_key("date", :date, default: date)
+
+          expect(subject.deserialize("{}")).to eq("date" => date)
+        end
+
+        it "preserves nil defaults" do
+          subject.add_typed_key("val", :integer, default: nil)
+
+          expect(subject.deserialize("{}")).to eq("val" => nil)
+        end
       end
     end
 


### PR DESCRIPTION
### What is the purpose of this pull request?

this enforces coercing in cases where the default is set up in a related-but-not-the-same type defined for the attribute.

this is required to work correctly which gems which extend on the activemodel attributes API, such as `store_model`, where the default is recommended to be defined as a hash for cases where the attribute type is defined as a nested store model type.

### What changes did you make? (overview)

The change is simply to apply the same `type.cast` operation on the default value, same as when the value is set.

### Is there anything you'd like reviewers to focus on?

While the patch wasn't AI-generated, the tests were. They may be "overtesting", so perhaps I'd focus on "filler" tests which don't add much and could be removed.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
