### PR TITLE
fix: defer Active Record patching via ActiveSupport.on_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Defer patching Active Record via `ActiveSupport.on_load(:active_record)` so requiring the gem no longer force-loads the JSON column type before app initializers run. ([@MattyMc](https://github.com/MattyMc))
+
 ## 2.1.1 (2026-01-13)
 
 - Fix defining store attributes after schema loading. ([@palkan][])

--- a/lib/store_attribute/active_record.rb
+++ b/lib/store_attribute/active_record.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 
-require "store_attribute/active_record/store"
+require "active_support/lazy_load_hooks"
+
+ActiveSupport.on_load(:active_record) do
+  require "store_attribute/active_record/store"
+end

--- a/spec/bugs/load_order_bug_spec.rb
+++ b/spec/bugs/load_order_bug_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "open3"
+require "rbconfig"
+
+RSpec.describe "load order" do
+  # Guard against store_attribute loading Active Record's JSON type before apps
+  # have configured their JSON encoder.
+  it "does not eagerly load active_record/type/json.rb" do
+    # Use a subprocess because spec_helper has already required store_attribute.
+    # This lets us observe which files are loaded by requiring the gem.
+    script = <<~'RUBY'
+      require "active_record"
+
+      json_type_features_before = $LOADED_FEATURES.grep(%r{/active_record/type/json\.rb\z})
+
+      require "store_attribute"
+
+      json_type_features_after = $LOADED_FEATURES.grep(%r{/active_record/type/json\.rb\z})
+      loaded_by_store_attribute = json_type_features_after - json_type_features_before
+
+      abort loaded_by_store_attribute.join("\n") if loaded_by_store_attribute.any?
+    RUBY
+
+    _stdout, stderr, status = Open3.capture3(RbConfig.ruby, "-e", script)
+
+    expect(status).to be_success, stderr
+  end
+end


### PR DESCRIPTION
Previously, requiring the gem force-loaded `active_record/type/json` during `Bundler.require`, before app initializers, so initializers that configure the JSON encoder (e.g., `Oj::Rails.set_encoder`) had no effect on json/jsonb columns in some Rails versions (e.g. 8.1.2). Now the patches load when `ActiveRecord::Base` does.

This follows Rails’ recommended pattern for applying configuration to framework classes: use a lazy load hook to avoid autoloading the class before initialization has completed. See the Rails guide note on [Avoid Loading Rails Frameworks](https://guides.rubyonrails.org/configuring.html#avoid-loading-rails-frameworks).

Fixes #60 

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme) – **N/A**
