### PR TITLE
Fix railsmaster CI with pglite 0.1.1 compatibility shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix test suite compatibility with Rails main (pglite shims). ([@MattyMc](https://github.com/MattyMc))
+
 ## 2.1.1 (2026-01-13)
 
 - Fix defining store attributes after schema loading. ([@palkan][])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,41 @@ elsif ActiveRecord::Base.respond_to?(:yaml_column_permitted_classes)
   ActiveRecord::Base.yaml_column_permitted_classes << Date
 end
 
+# pglite 0.1.1 is missing the connection methods that the latest Rails
+# calls (close, finished?, status), and it answers nil when Rails asks
+# parameter_status for the time zone. Getting no answer, Rails sets the
+# session time zone itself, and the wasm build cannot survive that
+# statement. It looks like it ships without time zone data, so any time
+# zone SET kills the instance for good. Answering "UTC" here means Rails
+# never sends it.
+#
+# The patch is pinned to this exact gem version so it retires itself on
+# the next pglite release. It also has to run before the first database
+# access. The support files connect at load time further down this file.
+if Gem::Version.new(PGlite::VERSION) <= Gem::Version.new("0.1.1")
+  # Rails main compares status to PG::CONNECTION_OK, a constant the pglite
+  # PG stub does not define. The real libpq value is 0.
+  PG.const_set(:CONNECTION_OK, 0) unless defined?(PG::CONNECTION_OK)
+
+  module PGliteRailsMainCompat
+    def close = nil
+
+    def finished? = false
+
+    def status = PG::CONNECTION_OK
+
+    def parameter_status(name)
+      # We cannot ask the embedded server for its time zone because that
+      # query also crashes it. Assume the wasm default of GMT, same as UTC.
+      return "UTC" if name.to_s.casecmp?("timezone")
+
+      super
+    end
+  end
+
+  PGlite::Connection.prepend(PGliteRailsMainCompat)
+end
+
 PGlite.install!(File.expand_path(File.join(__dir__, "../tmp/pglite")))
 
 ActiveRecord::Base.establish_connection(


### PR DESCRIPTION
pglite 0.1.1 is missing a few PG-compatible connection APIs that Rails main now calls during connection setup. It also returns `nil` for `parameter_status("TimeZone")`, which causes Rails to send a session time zone `SET` statement that crashes the wasm instance.

This PR adds a small compatibility shim for pglite 0.1.1 so the railsmaster CI job can run until pglite releases native support for these APIs.

Fixes #62 

### What is the purpose of this pull request?

Fix the `railsmaster` CI job when running against `pglite 0.1.1`.

### What changes did you make? (overview)

Added a version-pinned compatibility patch for `pglite <= 0.1.1` that:

* defines `PG::CONNECTION_OK` if missing
* adds `PGlite::Connection#close`
* makes `#finished?` report the connection as open
* adds `#status`
* returns `"UTC"` for `parameter_status("TimeZone")` so Rails does not send a time zone `SET`

The patch is intentionally scoped to `pglite <= 0.1.1` so it should retire once pglite ships the missing compatibility methods.

### Is there anything you'd like reviewers to focus on?

The main thing to review is whether `spec_helper.rb` is the right place for this temporary shim. It needs to run before any support files trigger database access.

### Checklist

* [x] I've added tests for this change. **Test already exists, the CI pipeline fail**
* [x] I've added a Changelog entry
* [x] I've updated a documentation (Readme). **N/A**

